### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
 before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.includes(:user)
+    @items = Item.includes(:user).order("create_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
 before_action :authenticate_user!, except: [:index, :show]
 
   def index
-
+    @item = Item.includes(:user)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
 before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @item = Item.includes(:user)
+    @items = Item.includes(:user)
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   has_one_attached :image
   belongs_to :user
+  has_one :order
   
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  #has_one :address
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,5 @@ class User < ApplicationRecord
   end
 
   has_many :items
+  has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,24 +127,27 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <% if %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+          <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +156,12 @@
         </div>
         <% end %>
       </li>
+    <% end %> 
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+    <% %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -161,9 +161,9 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-    <% %>
+    <% if @items.empty? %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to new_item_path do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -179,6 +179,7 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/db/migrate/20201208035526_create_orders.rb
+++ b/db/migrate/20201208035526_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user,           null: false, foreign_key: true
+      t.references :item,           null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_04_084548) do
+ActiveRecord::Schema.define(version: 2020_12_08_035526) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2020_12_04_084548) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2020_12_04_084548) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
＃What
商品一覧機能の実装をしました。

＃Why
・indexでItemモデルから全ての情報を取得。
・”新規投稿商品”から出品ページに遷移。
・商品ごとに画像・名前・価格・手数料負担先の一覧を表示

＃Gyazo
https://gyazo.com/ee7d6d311fe7a9f9ea2c67096d71bd65